### PR TITLE
fix: path to fzf-php-socket in preview closure

### DIFF
--- a/src/FuzzyFinder.php
+++ b/src/FuzzyFinder.php
@@ -289,7 +289,7 @@ class FuzzyFinder
 
         if ($this->preview instanceof Closure) {
             $basePath = Helpers::basePath();
-            $args['preview'] = "$basePath/bin/fzf-php-socket unix://$socketPath preview {}";
+            $args['preview'] = "$basePath/vendor/bin/fzf-php-socket unix://$socketPath preview {}";
         }
 
         return $args;


### PR DESCRIPTION
Is `Helpers::basePath()` supposed to return the path to the vendor folder or the project's base path? In my test project it returns the project base path, so the path to `fzf-php-socket` is wrong.